### PR TITLE
Use dependency-map ability of modulizer instead

### DIFF
--- a/dependency-map.txt
+++ b/dependency-map.txt
@@ -1,0 +1,7 @@
+d2l-colors,d2l-colors,git+https://github.com/BrightspaceUI/colors.git#polymer-3
+d2l-typography,d2l-typography,git+https://github.com/BrightspaceUI/typography.git#polymer-3
+d2l-offscreen,d2l-offscreen,git+https://github.com/BrightspaceUI/offscreen.git#polymer-3
+d2l-polymer-behaviors,d2l-polymer-behaviors,git+https://github.com/Brightspace/d2l-polymer-behaviors-ui.git#polymer-3.x
+d2l-icons,d2l-icons,git+https://github.com/BrightspaceUI/icons.git#polymer-3
+d2l-button,d2l-button,git+https://github.com/BrightspaceUI/button.git#polymer-3
+d2l-link,d2l-link,git+https://github.com/BrightspaceUI/link.git#polymer-3


### PR DESCRIPTION
This uses the technique @awikkerink talked about here: https://github.com/Brightspace/polymer-3-converter/issues/1

Pros:
- Separates the list out of the script
- People on Macs won't need to update their bash anymore

Concerns:
- We'll need to make this repo public to get the dependency map file easily (I think that's fine?)
- We lose the ability to tell if a component has already been converted to Polymer 3 or not, this just adds them to the `package.json` file without trying to install them

Thoughts?