### PR TITLE
adding map entry for siren-parser

### DIFF
--- a/dependency-map.txt
+++ b/dependency-map.txt
@@ -25,4 +25,5 @@ d2l-tooltip,d2l-tooltip,BrightspaceUI/tooltip#semver:^3.0.0
 d2l-typography,d2l-typography,BrightspaceUI/typography#semver:^7.0.1
 lie,lie,^3.3.0
 s-html,s-html,Brightspace/s-html#semver:^2.0.0
+siren-parser-import,siren-parser,^8.0.0
 stickyfill,stickyfilljs,^2.1.0


### PR DESCRIPTION
`siren-parser` was converted to an ES6 module and I archived `siren-parser-import` as a result as it's no longer needed.