### PR TITLE
Enhance script to look for lint:js

### DIFF
--- a/toPolymer3.sh
+++ b/toPolymer3.sh
@@ -140,6 +140,9 @@ echo "*** Update linting in package.json ***"
 sed -i.original '/\"lint\":/c\
 \    \"lint\": \"npm run lint:wc && npm run lint:js\",
 ' package.json
+sed -i.original '/\"lint:js\":/c\
+\    \"lint:js\": \"eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html\",
+' package.json
 sed -i.original '/\"lint:html\":/c\
 \    \"lint:js\": \"eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html\",
 ' package.json
@@ -148,6 +151,9 @@ sed -i.original '/\"lint:wc\":/c\
 ' package.json
 sed -i.original '/\"test:lint\":/c\
 \    \"test:lint\": \"npm run test:lint:wc && npm run test:lint:js\",
+' package.json
+sed -i.original '/\"test:lint:js\":/c\
+\    \"test:lint:js\": \"eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html\",
 ' package.json
 sed -i.original '/\"test:lint:html\":/c\
 \    \"test:lint:js\": \"eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html\",


### PR DESCRIPTION
We've run into this a few times now, where the linting script is already called `lint:js`, not `lint:html`.  The script will now first checks for the js version and replaces that, then looks and replaces the html version.